### PR TITLE
refactor(rules): The required check now uses `test`.

### DIFF
--- a/lib/ourscore.js
+++ b/lib/ourscore.js
@@ -6,8 +6,16 @@
 
 'use strict'; //jshint ignore:line
 
+exports.isBoolean = function (val) {
+  return Object.prototype.toString.call(val) === '[object Boolean]';
+};
+
 exports.isFunction = function (val) {
   return typeof val === 'function';
+};
+
+exports.isNumber = function (val) {
+  return Object.prototype.toString.call(val) === '[object Number]';
 };
 
 exports.isString = function (val) {

--- a/lib/types/any.js
+++ b/lib/types/any.js
@@ -18,18 +18,9 @@ module.exports = () => {
   let validator = (val) => {
     let origValue = val;
 
-    if (_.isUndefined(val)) {
-      if (validator._isOptional) {
-        return val;
-      } else {
-        throw new ReferenceError('missing value');
-      }
-    }
-
-    if (validator._allowed && _.contains(validator._allowed, val)) {
-      return val;
-    }
-
+    // Check the exclusive allowed list first. If an exclusive allowed list
+    // is defined and the value is not a member of list, throw
+    // a validation error
     if (validator._valid) {
       if (_.contains(validator._valid, val)) {
         return val;
@@ -38,12 +29,20 @@ module.exports = () => {
       throw toValidationError(origValue);
     }
 
+    // Check against the allowed list. If the value is not a member
+    // of the allowed list, continue
+    if (validator._allowed && _.contains(validator._allowed, val)) {
+      return val;
+    }
+
+    // Perform any transformations
     if (validator._transforms) {
-      val = validator._transforms.reduce((val, converter) => {
-        return converter(val);
+      val = validator._transforms.reduce((val, transform) => {
+        return transform(val);
       }, val);
     }
 
+    // Finally, perform the validations.
     if (validator._validators) {
       validator._validators.forEach((validator) => {
         if (! validator(val)) {
@@ -86,13 +85,11 @@ module.exports = () => {
   };
 
   /**
-   * Mark the field as optional
+   * Mark the field as optional. All fields are optional by default.
    *
    * @method optional
    */
-  validator._isOptional = true;
   validator.optional = function () {
-    this._isOptional = true;
     return this;
   };
 
@@ -102,7 +99,13 @@ module.exports = () => {
    * @method required
    */
   validator.required = function () {
-    this._isOptional = false;
+    this._isRequired = true;
+    this.test((val) => {
+      if (_.isUndefined(val)) {
+        throw new ReferenceError('missing value');
+      }
+      return true;
+    });
     return this;
   };
 
@@ -113,6 +116,21 @@ module.exports = () => {
    */
   validator.strict = function () {
     this._transforms = null;
+    return this;
+  };
+
+  /**
+   * Add a validation test function. Function will
+   * be called with value being validated.
+   *
+   * @method test
+   * @param {function} validator
+   */
+  validator.test = function (validator) {
+    if (! this._validators) {
+      this._validators = [];
+    }
+    this._validators.push(validator);
     return this;
   };
 
@@ -134,22 +152,7 @@ module.exports = () => {
   };
 
   /**
-   * Add a validation test function.
-   *
-   * @method test
-   * @param {function} validator
-   */
-  validator.test = function (validator) {
-    if (! this._validators) {
-      this._validators = [];
-    }
-    this._validators.push(validator);
-    return this;
-  };
-
-  /**
-   * If any `valid` calls are made, only items specified by `allowed` and
-   * `valid` will be accepted
+   * Create an exclusive allowed list of values.
    *
    * @method valid
    * @param {variant} val

--- a/lib/types/boolean.js
+++ b/lib/types/boolean.js
@@ -6,6 +6,8 @@
 
 'use strict'; //jshint ignore:line
 
+const _ = require('../ourscore');
+
 module.exports = (createValidator) => {
   return () => {
     var validator = createValidator();
@@ -20,8 +22,7 @@ module.exports = (createValidator) => {
       return val;
     })
     .test((val) => {
-      let actualType = Object.prototype.toString.call(val);
-      return actualType === '[object Boolean]';
+      return _.isBoolean(val) || _.isUndefined(val);
     });
 
     return validator;

--- a/lib/types/number.js
+++ b/lib/types/number.js
@@ -6,13 +6,14 @@
 
 'use strict'; //jshint ignore:line
 
+const _ = require('../ourscore');
+
 module.exports = (createValidator) => {
   return () => {
     var validator = createValidator();
 
     validator.transform((val) => {
-      let actualType = Object.prototype.toString.call(val);
-      if (actualType !== '[object Number]') {
+      if (! _.isNumber(val)) {
         if (/^\d+$/.test(val)) {
           return parseInt(val, 10);
         } else if (/^\d*\.\d*$/.test(val)) {
@@ -23,8 +24,7 @@ module.exports = (createValidator) => {
       return val;
     })
     .test((val) => {
-      let actualType = Object.prototype.toString.call(val);
-      return actualType === '[object Number]';
+      return _.isNumber(val) || _.isUndefined(val);
     });
 
     return validator;

--- a/lib/types/string.js
+++ b/lib/types/string.js
@@ -20,7 +20,7 @@ module.exports = (createValidator) => {
 
       return val;
     }).test((val) => {
-      return _.isString(val);
+      return _.isString(val) || _.isUndefined(val);
     });
 
     /**

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -42,8 +42,8 @@ function validate(data, schema) {
         }
 
         let targetKey = schema[key].as() || key;
-        // only add undefined values iff the value is not optional
-        if (! _.isUndefined(result.value) || ! schema[key]._isOptional) {
+        // only add undefined values iff the value is required
+        if (! _.isUndefined(result.value) || schema[key]._isRequired) {
           value[targetKey] = result.value;
         }
       });

--- a/tests/spec/any.js
+++ b/tests/spec/any.js
@@ -58,7 +58,7 @@ describe('types/any', () => {
   describe('with `optional`', () => {
     beforeEach(() => {
       func = null;
-      func = Validator.any().required().optional();
+      func = Validator.any().optional();
     });
 
     it('returns a function', () => {
@@ -73,6 +73,21 @@ describe('types/any', () => {
 
     it('returns `true` if the value is undefined', () => {
       expectSuccess(func, undefined);
+    });
+
+    describe('`optional` after `required`', () => {
+      beforeEach(() => {
+        func = null;
+        func = Validator.any().required().optional();
+      });
+
+      it('returns a function', () => {
+        assert.isFunction(func);
+      });
+
+      it('has no real effect, `required` takes precedence, error is thrown', () => {
+        expectReferenceError(func, undefined);
+      });
     });
   });
 

--- a/tests/spec/validator.js
+++ b/tests/spec/validator.js
@@ -88,12 +88,13 @@ describe('lib/validator', () => {
     describe('complex values', () => {
       let schema = {
         optional: Validator.string().optional(),
-        required: Validator.string().required().valid('valid')
+        required: Validator.string().required(),
+        requiredValid: Validator.string().required().valid('valid')
       };
 
       describe('with valid data', () => {
         beforeEach(() => {
-          result = Validator.validate({ required: 'valid' }, schema);
+          result = Validator.validate({ required: 'value', requiredValid: 'valid' }, schema);
         });
 
         it('returns an object with a null `error`', () => {
@@ -102,21 +103,37 @@ describe('lib/validator', () => {
 
         it('returns an object with `value` with expected fields', () => {
           assert.isObject(result.value);
-          assert.equal(Object.keys(result.value).length, 1);
+          assert.equal(Object.keys(result.value).length, 2);
         });
 
         it('sets the correct field value', () => {
-          assert.equal(result.value.required, 'valid');
+          assert.equal(result.value.required, 'value');
+          assert.equal(result.value.requiredValid, 'valid');
         });
 
       });
 
-      describe('with missing data', () => {
+      describe('with missing data for field with `valid`', () => {
         beforeEach(() => {
-          result = Validator.validate({}, schema);
+          result = Validator.validate({ required: 'value' }, schema);
         });
 
         it('returns an object with `error`', () => {
+          // TypeError is thrown with `valid` declarations
+          // and `undefined` values.
+          assert.instanceOf(result.error, TypeError);
+          assert.equal(result.error.key, 'requiredValid');
+        });
+      });
+
+      describe('with missing data for field without `valid`', () => {
+        beforeEach(() => {
+          result = Validator.validate({ requiredValid: 'valid' }, schema);
+        });
+
+        it('returns an object with `error`', () => {
+          // TypeError is thrown with `valid` declarations
+          // and `undefined` values.
           assert.instanceOf(result.error, ReferenceError);
           assert.equal(result.error.key, 'required');
         });
@@ -124,12 +141,12 @@ describe('lib/validator', () => {
 
       describe('with invalid data', () => {
         beforeEach(() => {
-          result = Validator.validate({ required: 'invalid' }, schema);
+          result = Validator.validate({ required: 'value', requiredValid: 'invalid' }, schema);
         });
 
         it('returns an object with `error`', () => {
           assert.instanceOf(result.error, TypeError);
-          assert.equal(result.error.key, 'required');
+          assert.equal(result.error.key, 'requiredValid');
         });
       });
 


### PR DESCRIPTION
Move some shared type checking code into ourscore.
