### PR TITLE
refactor(api): A schema is now an object, validate must be called to …

### DIFF
--- a/lib/types/any.js
+++ b/lib/types/any.js
@@ -14,24 +14,17 @@ function toValidationError(value) {
   return err;
 }
 
-module.exports = () => {
-  let validator = {
-    _allowed: [],
-    _transforms: [],
-    _valid: [],
-    _validators: []
-  };
-
+const any = {
   /**
    * Explicitly allow a value, before any conversion
    *
    * @method allow
    * @param {variant} val
    */
-  validator.allow = function (val) {
+  allow(val) {
     this._allowed.push(val);
     return this;
-  };
+  },
 
   /**
    * Export the result as {name} in the results.
@@ -39,30 +32,30 @@ module.exports = () => {
    * @method as
    * @param {string} name
    */
-  validator.as = function (name) {
+  as(name) {
     if (arguments.length === 0) {
       return this._as;
     }
 
     this._as = name;
     return this;
-  };
+  },
 
   /**
    * Mark the field as optional. All fields are optional by default.
    *
    * @method optional
    */
-  validator.optional = function () {
+  optional() {
     return this;
-  };
+  },
 
   /**
    * Mark the field as required
    *
    * @method required
    */
-  validator.required = function () {
+  required() {
     this._isRequired = true;
     this.test((val) => {
       if (_.isUndefined(val)) {
@@ -71,17 +64,17 @@ module.exports = () => {
       return true;
     });
     return this;
-  };
+  },
 
   /**
    * Remove any current transforms
    *
    * @method strict
    */
-  validator.strict = function () {
+  strict() {
     this._transforms = null;
     return this;
-  };
+  },
 
   /**
    * Add a validation test function. Function will
@@ -90,10 +83,10 @@ module.exports = () => {
    * @method test
    * @param {function} validator
    */
-  validator.test = function (validator) {
+  test(validator) {
     this._validators.push(validator);
     return this;
-  };
+  },
 
   /**
    * Add a transformer. A transformer is a function that accepts
@@ -103,10 +96,10 @@ module.exports = () => {
    * @method transform
    * @param {function} transformer
    */
-  validator.transform = function (transformer) {
+  transform(transformer) {
     this._transforms.push(transformer);
     return this;
-  };
+  },
 
   /**
    * Create an exclusive allowed list of values.
@@ -114,10 +107,10 @@ module.exports = () => {
    * @method valid
    * @param {variant} val
    */
-  validator.valid = function (val) {
+  valid(val) {
     this._valid.push(val);
     return this;
-  };
+  },
 
   /**
    * Validate a value
@@ -128,7 +121,7 @@ module.exports = () => {
    * transformations made.
    * @throws TypeError if validation fails
    */
-  validator.validate = function (val) {
+  validate(val) {
     let origValue = val;
 
     // Check the exclusive allowed list first. If an exclusive allowed list
@@ -165,7 +158,17 @@ module.exports = () => {
     }
 
     return val;
-  };
+  }
+};
+
+module.exports = () => {
+  let validator = Object.create(any);
+
+  validator._allowed = [];
+  validator._transforms = [];
+  validator._valid = [];
+  validator._validators = [];
+
 
   return validator;
 };

--- a/lib/types/any.js
+++ b/lib/types/any.js
@@ -15,43 +15,11 @@ function toValidationError(value) {
 }
 
 module.exports = () => {
-  let validator = (val) => {
-    let origValue = val;
-
-    // Check the exclusive allowed list first. If an exclusive allowed list
-    // is defined and the value is not a member of list, throw
-    // a validation error
-    if (validator._valid) {
-      if (_.contains(validator._valid, val)) {
-        return val;
-      }
-
-      throw toValidationError(origValue);
-    }
-
-    // Check against the allowed list. If the value is not a member
-    // of the allowed list, continue
-    if (validator._allowed && _.contains(validator._allowed, val)) {
-      return val;
-    }
-
-    // Perform any transformations
-    if (validator._transforms) {
-      val = validator._transforms.reduce((val, transform) => {
-        return transform(val);
-      }, val);
-    }
-
-    // Finally, perform the validations.
-    if (validator._validators) {
-      validator._validators.forEach((validator) => {
-        if (! validator(val)) {
-          throw toValidationError(origValue);
-        }
-      });
-    }
-
-    return val;
+  let validator = {
+    _allowed: [],
+    _transforms: [],
+    _valid: [],
+    _validators: []
   };
 
   /**
@@ -61,10 +29,6 @@ module.exports = () => {
    * @param {variant} val
    */
   validator.allow = function (val) {
-    if (! this._allowed) {
-      this._allowed = [];
-    }
-
     this._allowed.push(val);
     return this;
   };
@@ -127,9 +91,6 @@ module.exports = () => {
    * @param {function} validator
    */
   validator.test = function (validator) {
-    if (! this._validators) {
-      this._validators = [];
-    }
     this._validators.push(validator);
     return this;
   };
@@ -143,10 +104,6 @@ module.exports = () => {
    * @param {function} transformer
    */
   validator.transform = function (transformer) {
-    if (! this._transforms) {
-      this._transforms = [];
-    }
-
     this._transforms.push(transformer);
     return this;
   };
@@ -158,12 +115,56 @@ module.exports = () => {
    * @param {variant} val
    */
   validator.valid = function (val) {
-    if (! this._valid) {
-      this._valid = [];
-    }
-
     this._valid.push(val);
     return this;
+  };
+
+  /**
+   * Validate a value
+   *
+   * @method validate
+   * @param {variant} val
+   * @returns {variant} transformed value. The same as `val` if no
+   * transformations made.
+   * @throws TypeError if validation fails
+   */
+  validator.validate = function (val) {
+    let origValue = val;
+
+    // Check the exclusive allowed list first. If an exclusive allowed list
+    // is defined and the value is not a member of list, throw
+    // a validation error
+    if (this._valid.length) {
+      if (_.contains(this._valid, val)) {
+        return val;
+      }
+
+      throw toValidationError(origValue);
+    }
+
+    // Check against the allowed list. If the value is not a member
+    // of the allowed list, continue
+    if (this._allowed && _.contains(this._allowed, val)) {
+      return val;
+    }
+
+    // Perform any transformations
+    if (this._transforms) {
+      val = this._transforms.reduce((val, transform) => {
+        return transform(val);
+      }, val);
+    }
+
+    // Finally, perform the validations.
+    if (this._validators) {
+      this._validators.forEach((validator) => {
+        if (! validator(val)) {
+          throw toValidationError(origValue);
+        }
+      });
+    }
+
+    return val;
   };
 
   return validator;

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -24,9 +24,9 @@ function validate(data, schema) {
       throw missingSchemaError;
     }
 
-    if (_.isFunction(schema)) {
-      // schema function should return converted values
-      value = schema(data);
+    if (_.isFunction(schema.validate)) {
+      // validate function should return converted values
+      value = schema.validate(data);
     } else {
       // use the union to ensure all possible data has
       // a corresponding schema item and all possible schema

--- a/tests/lib/helpers.js
+++ b/tests/lib/helpers.js
@@ -8,35 +8,46 @@
 
 const assert = require('chai').assert;
 
-exports.expectSuccess = function (func, val, expected) {
+function validate(schema, value) {
+  return schema.validate ? schema.validate(value) : schema(value);
+}
+
+exports.expectSuccess = function (schema, value, expected) {
   if (arguments.length === 2) {
-    expected = val;
+    expected = value;
   }
 
-  let result = func(val);
+  let result = validate(schema, value);
 
   assert.strictEqual(result, expected);
 
   return result;
 };
 
-exports.expectTypeError = function (func, val) {
+exports.expectTypeError = function (schema, value) {
   let err;
   try {
-    func(val);
+    validate(schema, value);
   } catch (_err) {
     err = _err;
   }
   assert.instanceOf(err, TypeError);
-  assert.strictEqual(err.value, val);
+  assert.strictEqual(err.value, value);
 };
 
-exports.expectReferenceError = function (func, val) {
+exports.expectReferenceError = function (schema, value) {
   let err;
   try {
-    func(val);
+    validate(schema, value);
   } catch (_err) {
     err = _err;
   }
   assert.instanceOf(err, ReferenceError);
+};
+
+/**
+ * Is the item a schema
+ */
+exports.isSchema = function (schema) {
+  return !! schema.validate;
 };

--- a/tests/spec/any.js
+++ b/tests/spec/any.js
@@ -13,80 +13,81 @@ const Validator = require('../../lib/validator');
 const expectSuccess = Helpers.expectSuccess;
 const expectTypeError = Helpers.expectTypeError;
 const expectReferenceError = Helpers.expectReferenceError;
+const isSchema = Helpers.isSchema;
 
 describe('types/any', () => {
-  let func;
+  let schema;
 
   beforeEach(() => {
-    func = Validator.any();
+    schema = Validator.any();
   });
 
-  it('returns a function', () => {
-    assert.isFunction(func);
+  it('returns a schema', () => {
+    assert.isTrue(isSchema(schema));
   });
 
   it('success', () => {
-    expectSuccess(func, '', '');
-    expectSuccess(func, '123', '123');
-    expectSuccess(func, 123, 123);
+    expectSuccess(schema, '', '');
+    expectSuccess(schema, '123', '123');
+    expectSuccess(schema, 123, 123);
 
     // optional by default
-    expectSuccess(func, undefined);
+    expectSuccess(schema, undefined);
   });
 
   describe('with `required`', () => {
     beforeEach(() => {
-      func = null;
+      schema = null;
       // required overrules optional
-      func = Validator.any().required();
+      schema = Validator.any().required();
     });
 
-    it('returns a function', () => {
-      assert.isFunction(func);
+    it('returns a schema', () => {
+      assert.isTrue(isSchema(schema));
     });
 
     it('returns `true` for any values as long as they are defined', () => {
-      expectSuccess(func, '');
-      expectSuccess(func, '123');
+      expectSuccess(schema, '');
+      expectSuccess(schema, '123');
     });
 
     it('throws a ReferenceError if undefined', () => {
-      expectReferenceError(func, undefined);
+      expectReferenceError(schema, undefined);
     });
   });
 
   describe('with `optional`', () => {
     beforeEach(() => {
-      func = null;
-      func = Validator.any().optional();
+      schema = null;
+      schema = Validator.any().optional();
     });
 
-    it('returns a function', () => {
-      assert.isFunction(func);
+    it('returns a schema', () => {
+      assert.isTrue(isSchema(schema));
     });
 
     it('returns `true` for strings', () => {
-      expectSuccess(func, '');
-      expectSuccess(func, '123');
+      expectSuccess(schema, '');
+      expectSuccess(schema, '123');
     });
 
 
     it('returns `true` if the value is undefined', () => {
-      expectSuccess(func, undefined);
+      expectSuccess(schema, undefined);
     });
 
     describe('`optional` after `required`', () => {
       beforeEach(() => {
-        func = null;
-        func = Validator.any().required().optional();
+        schema = null;
+        schema = Validator.any().required().optional();
       });
 
-      it('returns a function', () => {
-        assert.isFunction(func);
+      it('returns a schema', () => {
+        assert.isTrue(isSchema(schema));
       });
 
       it('has no real effect, `required` takes precedence, error is thrown', () => {
-        expectReferenceError(func, undefined);
+        expectReferenceError(schema, undefined);
       });
     });
   });
@@ -94,133 +95,133 @@ describe('types/any', () => {
 
   describe('with `test`', () => {
     beforeEach(() => {
-      func = null;
-      func = Validator.any().test(function (val) {
+      schema = null;
+      schema = Validator.any().test((val) => {
         return /^valid/.test(val);
       });
     });
 
-    it('returns a function', () => {
-      assert.isFunction(func);
+    it('returns a schema', () => {
+      assert.isTrue(isSchema(schema));
     });
 
     it('returns `true` for strings that pass the validation function', () => {
-      expectSuccess(func, 'valid1');
-      expectSuccess(func, 'valid2');
+      expectSuccess(schema, 'valid1');
+      expectSuccess(schema, 'valid2');
     });
 
     it('throws a TypeError for items that do not pass the validation function', () => {
-      expectTypeError(func, 123);
-      expectTypeError(func, '123');
+      expectTypeError(schema, 123);
+      expectTypeError(schema, '123');
     });
 
     describe('with chained `test`', () => {
       beforeEach(() => {
-        func = null;
-        func = Validator.any().test((val) => {
+        schema = null;
+        schema = Validator.any().test((val) => {
           return /^valid/.test(val);
         }).test((val) => {
           return /\.name$/.test(val);
         });
       });
 
-      it('returns a function', () => {
-        assert.isFunction(func);
+      it('returns a schema', () => {
+        assert.isTrue(isSchema(schema));
       });
 
       it('returns `true` for strings that pass the validation function', () => {
-        expectSuccess(func, 'valid.name');
-        expectSuccess(func, 'valid1.name');
-        expectSuccess(func, 'valid.with.lots.of.random.stuff.name');
+        expectSuccess(schema, 'valid.name');
+        expectSuccess(schema, 'valid1.name');
+        expectSuccess(schema, 'valid.with.lots.of.random.stuff.name');
       });
 
       it('throws a TypeError for strings that do not pass the validation function', () => {
-        expectTypeError(func, 'validname');
-        expectTypeError(func, 'invalid.name');
+        expectTypeError(schema, 'validname');
+        expectTypeError(schema, 'invalid.name');
       });
     });
   });
 
   describe('with `allow`', () => {
     beforeEach(() => {
-      func = null;
-      func = Validator.any().test(function (val) {
+      schema = null;
+      schema = Validator.any().test((val) => {
         return /^valid/.test(val);
       }).allow('');
     });
 
-    it('returns a function', () => {
-      assert.isFunction(func);
+    it('returns a schema', () => {
+      assert.isTrue(isSchema(schema));
     });
 
     it('returns `true` for items that pass the validation function', () => {
-      expectSuccess(func, 'valid1');
-      expectSuccess(func, 'valid2');
+      expectSuccess(schema, 'valid1');
+      expectSuccess(schema, 'valid2');
     });
 
     it('returns `true` for tems that are allowed', () => {
-      expectSuccess(func, '');
+      expectSuccess(schema, '');
     });
 
     it('throws a TypeError for items that do not pass the validation function', () => {
-      expectTypeError(func, '123');
+      expectTypeError(schema, '123');
     });
   });
 
   describe('with `valid`', () => {
     beforeEach(() => {
-      func = null;
-      func = Validator.any().valid('this').valid('or').valid('that').valid(1);
+      schema = null;
+      schema = Validator.any().valid('this').valid('or').valid('that').valid(1);
     });
 
-    it('returns a function', () => {
-      assert.isFunction(func);
+    it('returns a schema', () => {
+      assert.isTrue(isSchema(schema));
     });
 
     it('returns `true` for items that are valid', () => {
-      expectSuccess(func, 'this');
-      expectSuccess(func, 'or');
-      expectSuccess(func, 'that');
-      expectSuccess(func, 1);
+      expectSuccess(schema, 'this');
+      expectSuccess(schema, 'or');
+      expectSuccess(schema, 'that');
+      expectSuccess(schema, 1);
     });
 
     it('throws a TypeError for all other values', () => {
-      expectTypeError(func, '');
-      expectTypeError(func, 'hey');
+      expectTypeError(schema, '');
+      expectTypeError(schema, 'hey');
     });
   });
 
   describe('with `as`', () => {
     beforeEach(() => {
-      func = null;
-      func = Validator.any().as('target');
+      schema = null;
+      schema = Validator.any().as('target');
     });
 
-    it('setter returns a function', () => {
-      assert.isFunction(func);
+    it('setter returns a schema', () => {
+      assert.isTrue(isSchema(schema));
     });
 
     it('getter returns value', () => {
-      assert.equal(func.as(), 'target');
+      assert.equal(schema.as(), 'target');
     });
   });
 
   describe('with `transform`', () => {
     beforeEach(() => {
-      func = null;
-      func = Validator.any().transform((val) => {
+      schema = null;
+      schema = Validator.any().transform((val) => {
         return val + '.suffix';
       }).transform((val) => {
         return val + '.second.suffix';
       });
     });
 
-    it('returns a function', () => {
-      assert.isFunction(func);
+    it('returns a schema', () => {
+      assert.isTrue(isSchema(schema));
     });
 
     it('function returns the transformed value', () => {
-      assert.equal(func('hey'), 'hey.suffix.second.suffix');
+      assert.equal(schema.validate('hey'), 'hey.suffix.second.suffix');
     });
   });
 });

--- a/tests/spec/boolean.js
+++ b/tests/spec/boolean.js
@@ -13,44 +13,45 @@ const Validator = require('../../lib/validator');
 const expectSuccess = Helpers.expectSuccess;
 const expectTypeError = Helpers.expectTypeError;
 const expectReferenceError = Helpers.expectReferenceError;
+const isSchema = Helpers.isSchema;
 
 describe('types/boolean', () => {
-  let func;
+  let schema;
 
   beforeEach(() => {
-    func = Validator.boolean();
+    schema = Validator.boolean();
   });
 
-  it('returns a function', () => {
-    assert.isFunction(func);
+  it('returns a schema', () => {
+    assert.isTrue(isSchema(schema));
   });
 
   it('returns `true` for boolean values or values that can be transformed to boolean', () => {
-    expectSuccess(func, true);
-    expectSuccess(func, 'true', true);
-    expectSuccess(func, false);
-    expectSuccess(func, 'false', false);
+    expectSuccess(schema, true);
+    expectSuccess(schema, 'true', true);
+    expectSuccess(schema, false);
+    expectSuccess(schema, 'false', false);
   });
 
   it('throws a TypeError if not', () => {
-    expectTypeError(func, 0);
-    expectTypeError(func, 1);
-    expectTypeError(func, {});
-    expectTypeError(func, []);
+    expectTypeError(schema, 0);
+    expectTypeError(schema, 1);
+    expectTypeError(schema, {});
+    expectTypeError(schema, []);
   });
 
   describe('strict', () => {
     beforeEach(() => {
-      func = Validator.boolean().strict();
+      schema = Validator.boolean().strict();
     });
 
-    it('returns a function', () => {
-      assert.isFunction(func);
+    it('returns a schema', () => {
+      assert.isTrue(isSchema(schema));
     });
 
     it('throws for values that can be transformed to boolean', () => {
-      expectTypeError(func, 'true');
-      expectTypeError(func, 'false');
+      expectTypeError(schema, 'true');
+      expectTypeError(schema, 'false');
     });
   });
 });

--- a/tests/spec/number.js
+++ b/tests/spec/number.js
@@ -13,48 +13,49 @@ const Validator = require('../../lib/validator');
 const expectSuccess = Helpers.expectSuccess;
 const expectTypeError = Helpers.expectTypeError;
 const expectReferenceError = Helpers.expectReferenceError;
+const isSchema = Helpers.isSchema;
 
 describe('types/number', () => {
-  let func;
+  let schema;
 
   beforeEach(() => {
-    func = Validator.number();
+    schema = Validator.number();
   });
 
-  it('returns a function', () => {
-    assert.isFunction(func);
+  it('returns a schema', () => {
+    assert.isTrue(isSchema(schema));
   });
 
   it('succeeds for numeric values or values that can be transformed to boolean', () => {
-    expectSuccess(func, 0);
-    expectSuccess(func, '1', 1);
-    expectSuccess(func, Infinity);
-    expectSuccess(func, '3.1415', 3.1415);
+    expectSuccess(schema, 0);
+    expectSuccess(schema, '1', 1);
+    expectSuccess(schema, Infinity);
+    expectSuccess(schema, '3.1415', 3.1415);
   });
 
   it('throws a TypeError if not', () => {
-    expectTypeError(func, true);
-    expectTypeError(func, false);
-    expectTypeError(func, {});
-    expectTypeError(func, []);
-    expectTypeError(func, '');
-    expectTypeError(func, 'NaN');
-    expectTypeError(func, '3.1415notanumber');
-    expectTypeError(func, 'asdf.jkl');
+    expectTypeError(schema, true);
+    expectTypeError(schema, false);
+    expectTypeError(schema, {});
+    expectTypeError(schema, []);
+    expectTypeError(schema, '');
+    expectTypeError(schema, 'NaN');
+    expectTypeError(schema, '3.1415notanumber');
+    expectTypeError(schema, 'asdf.jkl');
   });
 
   describe('strict', () => {
     beforeEach(() => {
-      func = Validator.boolean().strict();
+      schema = Validator.boolean().strict();
     });
 
-    it('returns a function', () => {
-      assert.isFunction(func);
+    it('returns a schema', () => {
+      assert.isTrue(isSchema(schema));
     });
 
     it('throws for values that can be transformed to boolean', () => {
-      expectTypeError(func, 'true');
-      expectTypeError(func, 'false');
+      expectTypeError(schema, 'true');
+      expectTypeError(schema, 'false');
     });
   });
 });

--- a/tests/spec/string.js
+++ b/tests/spec/string.js
@@ -13,113 +13,114 @@ const Validator = require('../../lib/validator');
 const expectSuccess = Helpers.expectSuccess;
 const expectTypeError = Helpers.expectTypeError;
 const expectReferenceError = Helpers.expectReferenceError;
+const isSchema = Helpers.isSchema;
 
 describe('types/string', () => {
-  let func;
+  let schema;
 
   beforeEach(() => {
-    func = Validator.string();
+    schema = Validator.string();
   });
 
-  it('returns a function', () => {
-    assert.isFunction(func);
+  it('returns a schema', () => {
+    assert.isTrue(isSchema(schema));
   });
 
   it('success', () => {
-    expectSuccess(func, '', '');
-    expectSuccess(func, '123', '123');
+    expectSuccess(schema, '', '');
+    expectSuccess(schema, '123', '123');
     // strings are trimmed by default
-    expectSuccess(func, ' 123', '123');
-    expectSuccess(func, '123 ', '123');
+    expectSuccess(schema, ' 123', '123');
+    expectSuccess(schema, '123 ', '123');
     // optional by default
-    expectSuccess(func, undefined);
+    expectSuccess(schema, undefined);
   });
 
   it('throws a TypeError for non-strings', () => {
-    expectTypeError(func, null);
-    expectTypeError(func, true);
-    expectTypeError(func, 1);
-    expectTypeError(func, {});
-    expectTypeError(func, []);
+    expectTypeError(schema, null);
+    expectTypeError(schema, true);
+    expectTypeError(schema, 1);
+    expectTypeError(schema, {});
+    expectTypeError(schema, []);
   });
 
   describe('strict', () => {
     beforeEach(() => {
-      func = Validator.string().strict();
+      schema = Validator.string().strict();
     });
 
-    it('returns a function', () => {
-      assert.isFunction(func);
+    it('returns a schema', () => {
+      assert.isTrue(isSchema(schema));
     });
 
     it('success', () => {
       // strings are not trimmed
-      expectSuccess(func, ' 123', ' 123');
-      expectSuccess(func, '123 ', '123 ');
+      expectSuccess(schema, ' 123', ' 123');
+      expectSuccess(schema, '123 ', '123 ');
     });
   });
 
   describe('len', () => {
     beforeEach(() => {
-      func = Validator.string().len(2);
+      schema = Validator.string().len(2);
     });
 
-    it('returns a function', () => {
-      assert.isFunction(func);
+    it('returns a schema', () => {
+      assert.isTrue(isSchema(schema));
     });
 
     it('success', () => {
-      expectSuccess(func, '12', '12');
+      expectSuccess(schema, '12', '12');
     });
 
     it('throws a TypeError if too short', () => {
-      expectTypeError(func, '');
-      expectTypeError(func, '1');
+      expectTypeError(schema, '');
+      expectTypeError(schema, '1');
     });
 
     it('throws a TypeError if too long', () => {
-      expectTypeError(func, '123');
+      expectTypeError(schema, '123');
     });
   });
 
   describe('min', () => {
     beforeEach(() => {
-      func = Validator.string().min(2);
+      schema = Validator.string().min(2);
     });
 
-    it('returns a function', () => {
-      assert.isFunction(func);
+    it('returns a schema', () => {
+      assert.isTrue(isSchema(schema));
     });
 
     it('success', () => {
-      expectSuccess(func, '12', '12');
-      expectSuccess(func, '123', '123');
+      expectSuccess(schema, '12', '12');
+      expectSuccess(schema, '123', '123');
     });
 
     it('throws a TypeError if too short', () => {
-      expectTypeError(func, '');
-      expectTypeError(func, '1');
+      expectTypeError(schema, '');
+      expectTypeError(schema, '1');
     });
   });
 
   describe('max', () => {
     beforeEach(() => {
-      func = Validator.string().max(2);
+      schema = Validator.string().max(2);
     });
 
-    it('returns a function', () => {
-      assert.isFunction(func);
+    it('returns a schema', () => {
+      assert.isTrue(isSchema(schema));
     });
 
     it('success', () => {
-      expectSuccess(func, '', '');
-      expectSuccess(func, '1', '1');
-      expectSuccess(func, '12', '12');
+      expectSuccess(schema, '', '');
+      expectSuccess(schema, '1', '1');
+      expectSuccess(schema, '12', '12');
     });
 
     it('throws a TypeError if too long', () => {
-      expectTypeError(func, '123');
-      expectTypeError(func, '124');
+      expectTypeError(schema, '123');
+      expectTypeError(schema, '124');
     });
   });
 });

--- a/tests/spec/validator.js
+++ b/tests/spec/validator.js
@@ -7,40 +7,12 @@
 'use strict'; //jshint ignore:line
 
 const assert = require('chai').assert;
+const Helpers = require('../lib/helpers');
 const Validator = require('../../lib/validator');
 
-function expectSuccess(func, val, expected) {
-  if (arguments.length === 2) {
-    expected = val;
-  }
-
-  let result = func(val);
-
-  assert.strictEqual(result, expected);
-
-  return result;
-}
-
-function expectTypeError(func, val) {
-  let err;
-  try {
-    func(val);
-  } catch (_err) {
-    err = _err;
-  }
-  assert.instanceOf(err, TypeError);
-  assert.strictEqual(err.value, val);
-}
-
-function expectReferenceError(func, val) {
-  let err;
-  try {
-    func(val);
-  } catch (_err) {
-    err = _err;
-  }
-  assert.instanceOf(err, ReferenceError);
-}
+const expectSuccess = Helpers.expectSuccess;
+const expectTypeError = Helpers.expectTypeError;
+const expectReferenceError = Helpers.expectReferenceError;
 
 describe('lib/validator', () => {
   describe('interface', () => {


### PR DESCRIPTION
…validate.
