### PR TITLE
feat(api): Allow `test` to accept a RegExp for Strings

### DIFF
--- a/lib/types/string.js
+++ b/lib/types/string.js
@@ -6,45 +6,62 @@
 
 'use strict'; //jshint ignore:line
 
-const string = {
-  /**
-   * Specifies the exact string length required
-   *
-   * @method len
-   * @param {number} limit
-   */
-  len(limit) {
-    return this.test((val) => {
-      return val.length === limit;
-    });
-  },
-
-  /**
-   * Specifies the maximum number of characters allowed (inclusive)
-   *
-   * @method max
-   * @param {number} limit
-   */
-  max(limit) {
-    return this.test((val) => {
-      return val.length <= limit;
-    });
-  },
-
-  /**
-   * Specifies the minimum number of characters allowed (inclusive)
-   *
-   * @method min
-   * @param {number} limit
-   */
-  min(limit) {
-    return this.test((val) => {
-      return val.length >= limit;
-    });
-  }
-};
-
 module.exports = (vat) => {
+
+  const string = {
+    /**
+     * Specifies the exact string length required
+     *
+     * @method len
+     * @param {number} limit
+     */
+    len(limit) {
+      return this.test((val) => {
+        return val.length === limit;
+      });
+    },
+
+    /**
+     * Specifies the maximum number of characters allowed (inclusive)
+     *
+     * @method max
+     * @param {number} limit
+     */
+    max(limit) {
+      return this.test((val) => {
+        return val.length <= limit;
+      });
+    },
+
+    /**
+     * Specifies the minimum number of characters allowed (inclusive)
+     *
+     * @method min
+     * @param {number} limit
+     */
+    min(limit) {
+      return this.test((val) => {
+        return val.length >= limit;
+      });
+    },
+
+    /**
+     * Override test to accept regular expressions
+     *
+     * @method test
+     * @param {function|regexp} validator
+     */
+    test(validator) {
+      if (validator instanceof RegExp) {
+        const regExp = validator;
+        validator = (val) => {
+          return regExp.test(val);
+        };
+      }
+      return vat.any().test.call(this, validator);
+    }
+  };
+
   const _ = vat.utils;
   return vat.any().clone().extend(string).transform((val) => {
     // trim strings by default

--- a/tests/spec/string.js
+++ b/tests/spec/string.js
@@ -123,6 +123,20 @@ describe('types/string', () => {
       expectTypeError(schema, '124');
     });
   });
+
+  describe('test', () => {
+    describe('with a regexp', () => {
+      beforeEach(() => {
+        schema = vat.string().test(/foo/);
+      });
+
+      it('success', () => {
+        expectSuccess(schema, 'foobar', 'foobar');
+      });
+
+      it('throws a TypeError if no match', () => {
+        expectTypeError(schema, 'bar');
+      });
+    });
+  });
 });
-
-


### PR DESCRIPTION
@philbooth - The other week you opened a content-server PR to validate incoming metricsContext data, the validation used a simple RegExp matcher. One question I had (though did not write) was whether we would use VAT for the job since we use it in the front-end. We could have used VAT but it would have been more verbose because VAT doesn't accept simple RegExp's in the `test` function.

This is a PR to change that.

Usage:

```js
const schema = Vat.string().test(/foo/);
```

Do you think this is a reasonable API addition? If so, think it makes sense on String only?