### PR TITLE
feat(options): Add an `allowUnknown` option.

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1,7 +1,7 @@
 
 # VAT API Reference
 
-## Version 0.0.5
+## Version 0.0.9
 
 * [register](#registertypename-schema)
 * [unregister](#unregistertypename)
@@ -58,11 +58,13 @@ Unregister a type.
 vat.unregister('hex');
 ```
 
-## `validate(data, schema)`
+## `validate(data, schema, options)`
 Validate data against the schema.
 
 * `data` |Variant| value to be validated
 * `schema` |Schema| schema to use to validate
+* `options` |Object| Optional options
+  * `options.allowUnknown` |Boolean| when true, allows object to contain unknown keys. Defaults to false.
 
 Returns an object containing:
 * |Error| result.error - any error thrown. If validating an object, `error` will
@@ -182,18 +184,19 @@ const strictlyBooleanSchema = vat.boolean().strict();
 ```
 
 ### `any.test(validator)`
-Add a validation test function. Function will be called with
+Add a validation test function or RegExp. Function will be called with
 value being validated.
 
-* `validator` |Function| validation function
+* `validator` |Function_or_RegExp| validation function or RegExp
 
 Returns a Schema.
 
 ```js
+// hexSchema and altHexSchema only allow hex strings.
 const hexSchema = vat.string().test((val) => {
   return /[a-f0-9]+/.test(val);
 });
-// hexSchema only allows hex strings.
+const altHexSchema = vat.string().test(/[a-f0-9]+/);
 ```
 
 ### `any.transform(transformer)`
@@ -341,7 +344,7 @@ If validating an object, returned error will contain a `key` field that
 contains the name of the failed item.
 
 ### `TypeError`
-Returend if a field is defined but does not pass validation.
+Returned if a field is defined but does not pass validation.
 
 If validating an object, returned error will contain a `key` field that
 contains the name of the failed item.

--- a/docs/api.md
+++ b/docs/api.md
@@ -338,13 +338,17 @@ const minLengthSchema = vat.string().min(1);
 
 ## Validation Errors
 ### `ReferenceError`
-Returned if a required field is missing from the passed in data object or is undefined.
+Returned in the following cases:
 
-If validating an object, returned error will contain a `key` field that
+* Vat.validate is called without a schema.
+* A required field is missing or undefined.
+* An unknown key is present and `allowUnknown` is `false`.
+
+If validating an object, the returned error will contain a `key` field that
 contains the name of the failed item.
 
 ### `TypeError`
 Returned if a field is defined but does not pass validation.
 
-If validating an object, returned error will contain a `key` field that
+If validating an object, the returned error will contain a `key` field that
 contains the name of the failed item.

--- a/lib/vat.js
+++ b/lib/vat.js
@@ -13,11 +13,15 @@ const _ = require('./utils');
  *
  * @param {variant} data - data to validate
  * @param {Schema} schema - schema to use to validate
+ * @param {Object} [options] - options
+ *   @param {Boolean} [options.allowUnknown] - when true, allows object to contain unknown keys. Defaults to false.
  * @returns {object} result
  *   @returns {Error} result.error - any error thrown
  *   @returns {variant} result.value - transformed data
  */
-function validate(data, schema) {
+function validate(data, schema, options) {
+  options = options || {};
+
   let error = null;
   let value = data;
 
@@ -36,17 +40,24 @@ function validate(data, schema) {
       let allKeys = _.union(Object.keys(data), Object.keys(schema));
       value = {};
       allKeys.forEach(function (key) {
-        let result = validate(data[key], schema[key]);
+        if (schema[key]) {
+          let result = validate(data[key], schema[key], options);
+          if (result.error) {
+            result.error.key = key;
+            throw result.error;
+          }
 
-        if (result.error) {
-          result.error.key = key;
-          throw result.error;
-        }
-
-        let targetKey = schema[key].renameTo() || key;
-        // only add undefined values iff the value is required
-        if (! _.isUndefined(result.value) || schema[key]._isRequired) {
-          value[targetKey] = result.value;
+          let targetKey = schema[key].renameTo() || key;
+          // only add undefined values iff the value is required
+          if (! _.isUndefined(result.value) || schema[key]._isRequired) {
+            value[targetKey] = result.value;
+          }
+        } else if (options.allowUnknown) {
+          value[key] = data[key];
+        } else {
+          const error = new ReferenceError(`'${key}' is not allowed`);
+          error.key = key;
+          throw error;
         }
       });
     }

--- a/lib/vat.js
+++ b/lib/vat.js
@@ -41,13 +41,13 @@ function validate(data, schema, options) {
       value = {};
       allKeys.forEach(function (key) {
         if (schema[key]) {
-          let result = validate(data[key], schema[key], options);
+          const result = validate(data[key], schema[key], options);
           if (result.error) {
             result.error.key = key;
             throw result.error;
           }
 
-          let targetKey = schema[key].renameTo() || key;
+          const targetKey = schema[key].renameTo() || key;
           // only add undefined values iff the value is required
           if (! _.isUndefined(result.value) || schema[key]._isRequired) {
             value[targetKey] = result.value;

--- a/tests/spec/vat.js
+++ b/tests/spec/vat.js
@@ -173,6 +173,38 @@ describe('lib/vat', () => {
           assert.isTrue(result.value.bool);
         });
       });
+
+      describe('with an extra key', () => {
+        beforeEach(() => {
+          schema = {
+            bool: vat.boolean()
+          };
+        });
+
+        describe('allowUnknown: false (default)', () => {
+          beforeEach(() => {
+            result = vat.validate({ bool: 'true', string: 'a string' }, schema);
+          });
+
+          it('errors on the extra field', () => {
+            assert.ok(result.error);
+            assert.equal(result.error.key, 'string');
+          });
+        });
+
+
+        describe('allowUnknown: true', () => {
+          beforeEach(() => {
+            result = vat.validate({ bool: true, string: 'a string' }, schema, { allowUnknown: true });
+          });
+
+          it('does not error with extra field', () => {
+            assert.isNull(result.error);
+            assert.equal(result.value.bool, true);
+            assert.equal(result.value.string, 'a string');
+          });
+        });
+      });
     });
   });
 


### PR DESCRIPTION
`allowUnknown` allows extra data fields to exist in an object being validated.